### PR TITLE
Update DNSCrypt to 1.0.5

### DIFF
--- a/Casks/dnscrypt.rb
+++ b/Casks/dnscrypt.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'dnscrypt' do
-  version '1.0.4'
+  version '1.0.5'
   sha256 '14e08b4e4bba7e7a0761e318eca559a980e95dc46fafd7251011785f0cf10993'
 
   url "https://github.com/alterstep/dnscrypt-osxclient/releases/download/#{version}/dnscrypt-osxclient-#{version}.dmg"


### PR DESCRIPTION
Upstream Release Notes
- Updated DNSCrypt proxy to version 1.4.3 (from 1.4.1)
- Updated libsodium to 1.0.1-minimal (from 0.7.0-minimal)
